### PR TITLE
board_plop fix

### DIFF
--- a/board.c
+++ b/board.c
@@ -273,9 +273,6 @@ void board_plop(struct board* board) {
 	// Count number of empty tiles.
 	tiles_empty = board_get_tiles_empty(board);
 
-	if (tiles_empty == 0)
-		return;
-
 	// Choose a random tile to palce the value into.
 	target = rand() % tiles_empty;
 

--- a/main.c
+++ b/main.c
@@ -190,17 +190,14 @@ int main(int argc, char* argv[]) {
 		else
 			valid = -1;
 
-		if (!raw) {
-			// Prepare for user's next move.
-			if (valid == 0) {
-				fputs("Invalid move.\n", stdout);
-			} else if (valid == 1) {
+		// Prepare for user's next move.
+		if (raw || valid == 1) {
+			if (board_get_tiles_empty(&board) != 0)
 				board_plop(&board);
-			} else {
-				fputs("Invalid command.\n", stdout);
-			}
+		} else if (valid == 0) {
+			fputs("Invalid move.\n", stdout);
 		} else {
-			board_plop(&board);
+			fputs("Invalid command.\n", stdout);
 		}
 	}
 


### PR DESCRIPTION
This fixes a divide-by-zero exception that occurs in `board_plop` when the board is full.
