### PR TITLE
Restore terminal mode on exit

### DIFF
--- a/io.c
+++ b/io.c
@@ -1,8 +1,12 @@
 #include "io.h"
 
 
+struct termios saved_term_settings;
+
+
 void sigint_handler(int signum) {
-	fputs("\33[?1049l", stdout);
+	restore_mode();
+	leave_alternate_buffer();
 	exit(1);
 }
 
@@ -37,10 +41,16 @@ void enter_raw_mode(struct termios* term_settings) {
 
 	tcgetattr(STDOUT_FILENO, term_settings);
 
+	saved_term_settings = *term_settings;
+
 	term_settings->c_lflag &= ~(ICANON | ECHO);
 
 	tcsetattr(STDOUT_FILENO, TCSADRAIN, term_settings);
 
 	setvbuf(stdin, NULL, _IONBF, BUFSIZ);
 	setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+}
+
+void restore_mode() {
+	tcsetattr(STDOUT_FILENO, TCSADRAIN, &saved_term_settings);
 }

--- a/io.h
+++ b/io.h
@@ -11,10 +11,14 @@
 
 
 /**
- * Puts the TTY into some kind of raw mode
+ * Puts the terminal into some kind of raw mode.
  */
 void enter_raw_mode(struct termios* term_settings);
 
+/**
+ * Restores the original terminal mode.
+ */
+void restore_mode();
 
 /**
  * Sets up a SIGINT handler to switch back to the regular buffer.

--- a/main.c
+++ b/main.c
@@ -209,6 +209,7 @@ int main(int argc, char* argv[]) {
 	if (raw) {
 		fputs("Press space to exit.\n", stdout);
 		while (getchar() != ' ') { /* wait */ }
+		restore_mode();
 		leave_alternate_buffer();
 	}
 


### PR DESCRIPTION
This restores the terminal mode when the program exits normally or because of a SIGINT.
