### PR TITLE
Fix strncat usage

### DIFF
--- a/board.c
+++ b/board.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2014-2015 by Wade T. Cline (Frostsnow)
+ *  Copyright 2014-2015, 2024 by Wade T. Cline (Frostsnow)
  *
  *  "2048" is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -115,13 +115,13 @@ void board_init_score(struct board* board) {
 		fprintf(stderr, "Directory path too long.");
 		goto out;
 	}
-	strncat(directory_path, "/.2048", strlen("/.2048"));
+	strncat(directory_path, "/.2048", sizeof(directory_path) - 1);
 	strncpy(file_path, home, sizeof(file_path));
 	if (strlen(file_path) + strlen("/.2048/score_top") + 1 > 128) {
 		fprintf(stderr, "File path too long.");
 		goto out;
 	}
-	strncat(file_path, "/.2048/score_top", sizeof("/.2048/score_top"));
+	strncat(file_path, "/.2048/score_top", sizeof(file_path) - 1);
 
 	// Open the top scores file.
 	if ((board->score_file = open(file_path, O_RDWR)) == -1) {

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2014-2015 by Wade T. Cline (Frostsnow)
+ *  Copyright 2014-2015, 2024 by Wade T. Cline (Frostsnow)
  *
  *  "2048" is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -30,10 +30,10 @@
 #include "io.h"
 
 
-#define VERSION "2.0.0"
+#define VERSION "2.0.1"
 
 char* legal =
-	"2048 (implemented in C)  Copyright (C) 2014  Wade T. Cline\n"
+	"2048 (implemented in C)  Copyright (C) 2014-2015, 2024 Wade T. Cline\n"
 	"This program comes with ABSOLUTELY NO WARRANTY. This is\n"
 	"free software, and you are welcome to redistribute it\n"
 	"under certain conditions. See the file 'COPYING' in the\n"

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@
 #  along with "2048".  If not, see <http://www.gnu.org/licenses/>.
 
 compiler = gcc
-flags = -Wall -Werror --pedantic-errors --std=c99
+flags = -Wall --pedantic-errors --std=c99
 #libraries = -lm
 files = arguments board main io
 manpage = 2048.1


### PR DESCRIPTION
For some reason I had used the source length instead of destination length as the ssize parameter.  Use the destination length minus one instead.  Also remove '-Werror' from the default makefile.

Closes: #14